### PR TITLE
saving file in binary format to fix Encoding::UndefinedConversionError

### DIFF
--- a/lib/web_font/downloader.rb
+++ b/lib/web_font/downloader.rb
@@ -22,14 +22,13 @@ module WebFont
 
         if from_cache && LocalCache.enable? && cache_path = LocalCache.path(filename)
           FileUtils.copy(cache_path, destination_path)
-          downloaded_fonts << font_path
         else
           unless File.exist?(font_path)
             HTTP.get(url, font_path)
             LocalCache.save(font_path)
-            downloaded_fonts << font_path
           end
         end
+        downloaded_fonts << font_path
       end
 
       downloaded_fonts

--- a/lib/web_font/http.rb
+++ b/lib/web_font/http.rb
@@ -2,7 +2,7 @@ module WebFont
   module HTTP
     def self.get(uri, output_path)
       json_str = Net::HTTP.get(URI(uri))
-      File.open(output_path, 'w') { |fp| fp.puts(json_str) }
+      File.open(output_path, 'wb') { |fp| fp.puts(json_str) }
     end
   end
 end


### PR DESCRIPTION
I was getting this error Encoding::UndefinedConversionError: "\xBE" from ASCII-8BIT to UTF-8 when downloading fonts. I changed the write mode to binary and that fixed the problem 